### PR TITLE
Fix files__create to return TRUE after closing file

### DIFF
--- a/src/files.kl
+++ b/src/files.kl
@@ -237,7 +237,7 @@ ROUTINE files__create
       RETURN(TRUE)
     ELSE
       files__close(filename, fl)
-      RETURN(FALSE)
+      RETURN(TRUE)
     ENDIF 
   END files__create
 


### PR DESCRIPTION
Previously, files__create returned FALSE after closing the file in the ELSE branch. This commit changes the return value to TRUE, ensuring consistent success indication.